### PR TITLE
DN-2 Make backend running

### DIFF
--- a/ninja-be/build.gradle
+++ b/ninja-be/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'org.springframework.ai:spring-ai-qdrant-store-spring-boot-starter'
     implementation 'org.springframework.session:spring-session-core'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/ninja-be/src/main/java/pl/ochnios/ninjabe/NinjaBeApplication.java
+++ b/ninja-be/src/main/java/pl/ochnios/ninjabe/NinjaBeApplication.java
@@ -11,3 +11,4 @@ public class NinjaBeApplication {
     }
 
 }
+

--- a/ninja-be/src/main/resources/application.properties
+++ b/ninja-be/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=ninja-be

--- a/ninja-be/src/main/resources/application.yml
+++ b/ninja-be/src/main/resources/application.yml
@@ -1,0 +1,38 @@
+server:
+  port: 8080
+
+spring:
+  application:
+    name: ninja-be
+
+  autoconfigure:
+    exclude: >
+      org.springframework.ai.autoconfigure.openai.OpenAiAutoConfiguration,
+      org.springframework.ai.autoconfigure.vectorstore.qdrant.QdrantVectorStoreAutoConfiguration
+
+  datasource:
+    url: jdbc:h2:mem:ninjadb
+    username: sa
+    password: sa
+    driverClassName: org.h2.Driver
+
+  h2:
+    console:
+      enabled: true
+
+  jpa:
+    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create-drop
+
+logging:
+  level:
+    org:
+      springframework:
+        web: INFO
+      hibernate:
+        SQL: DEBUG
+        type:
+          descriptor:
+            sql:
+              BasicBinder: TRACE


### PR DESCRIPTION
Finish backend initialization:
- use H2 database for development
- disable autocofiguration for openai and vectore store as multiple instances would be configured on runtime
- change application .properties to .yaml